### PR TITLE
Fixed Path Bugs in Paw Parser

### DIFF
--- a/src/parsers/paw/__tests__/Parser.spec.js
+++ b/src/parsers/paw/__tests__/Parser.spec.js
@@ -595,13 +595,28 @@ describe('parsers/paw/Parser.js', () => {
   describe('@findIntersection', () => {
     it('should work', () => {
       const defaultUrl = 'http://echo.paw.cloud/pets'
-      const inputs = [ '/pets', '/pets/234', '/234' ]
+      const defaultSecureUrl = 'https://echo.paw.cloud/pets'
+      const inputs = [
+        '/pets',
+        '/pets/234',
+        '/234',
+        // this one should be outside, because our intersection method tries to place strings so
+        // that they overlap from the right
+        'http://echo.paw.cloud',
+        'http://echo.paw.cloud/pets',
+        'https://echo.paw.cloud/pets'
+      ]
       const expected = [
         { inside: '/pets', outside: '' },
         { inside: '/pets', outside: '/234' },
-        { inside: '', outside: '/234' }
+        { inside: '', outside: '/234' },
+        { inside: '', outside: 'http://echo.paw.cloud' },
+        { inside: 'http://echo.paw.cloud/pets', outside: '' },
+        { inside: 'https://echo.paw.cloud/pets', outside: '' }
       ]
-      const actual = inputs.map(input => __internals__.findIntersection(defaultUrl, input))
+      const actual = inputs.map(
+        input => __internals__.findIntersection(defaultUrl, defaultSecureUrl, input)
+      )
       expect(actual).toEqual(expected)
     })
   })


### PR DESCRIPTION
When a single slash existed in between two components in the paw parser, it was removed, as it was considered a part of the base URL. **[fixed]**

When the first component of a DynamicString representing a path contained all of a secure protocol, a host and a path different from '/', the component would not be correctly intersected with the host URL. **[fixed]**